### PR TITLE
Enable arrow function parentheses

### DIFF
--- a/index.json
+++ b/index.json
@@ -4,6 +4,6 @@
   "semi": true,
   "singleQuote": true,
   "bracketSpacing": false,
-  "quoteProps": "consistent"
+  "quoteProps": "consistent",
+  "arrowParens": "always"
 }
-


### PR DESCRIPTION
Adds the [arrow function parentheses](https://prettier.io/docs/en/options.html#arrow-function-parentheses) config option and sets it to the default value for prettier v2.

