### PR TITLE
Fix missing fs package in bump.js

### DIFF
--- a/bump.js
+++ b/bump.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const packageJson = fs.readFileSync("./package.json").toString("utf8");
 const json = JSON.parse(packageJson);
 json.version = `1.1.${process.env.CIRCLE_BUILD_NUM}`;


### PR DESCRIPTION
# Fix missing fs package in bump.js

## Description

Publish failed on undefined `fs` variable. Define it before using it
